### PR TITLE
Use run_exports max_pin of x.x.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   run_exports:
-    - {{ pin_subpackage("azure-storage-common-cpp", max_pin="x.x") }}
+    - {{ pin_subpackage("azure-storage-common-cpp", max_pin="x.x.x") }}
 
 # https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/vcpkg/vcpkg.json
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

No binary compatibility between releases

xref: https://github.com/Azure/azure-sdk-for-cpp/issues/5322, https://github.com/conda-forge/azure-core-cpp-feedstock/pull/11#issuecomment-1927972737, https://github.com/conda-forge/azure-core-cpp-feedstock/pull/14

Note: rerendering had no effect