### PR TITLE
Rebuild for azure_core_cpp 1.13.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,5 @@
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/migrations/azure_core_cpp1130.yaml
+++ b/.ci_support/migrations/azure_core_cpp1130.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for azure_core_cpp 1.13.0
+  kind: version
+  migration_number: 1
+azure_core_cpp:
+- 1.13.0
+azure_storage_common_cpp:
+- 12.7.0
+migrator_ts: 1720864534.0175145

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '10.13'
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 azure_core_cpp:
-- 1.12.0
+- 1.13.0
 c_stdlib:
 - vs
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("azure-storage-common-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
This is blocking the migration, because the two packages were coupled in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6157